### PR TITLE
add .gitlab-ci.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,11 @@
+image: "golang:1.11"
+
+before_script:
+  - mkdir -p /go/src/github.com
+  - cp -r /builds/katzenpost /go/src/github.com/katzenpost/
+  - cd /go/src/github.com/katzenpost/panda
+  - go get -v -t ./...
+
+test-panda:
+  script:
+    - go test -v -cover -race ./...


### PR DESCRIPTION
Adds a .gitlab-ci.yml. Tested on CCT's gitlab.
Note: tests are currently failing because packages 'plugin' changed to 'grpcplugin' and 'cborplugin'